### PR TITLE
wms: handle legend URLs from getCapabilities

### DIFF
--- a/src/components/map/components/legend/selectors.js
+++ b/src/components/map/components/legend/selectors.js
@@ -16,6 +16,8 @@ const selectCountryDataLoading = (state) =>
   state.countryData && state.countryData.loading;
 const selectLayerTimestamps = (state) =>
   state.datasets && state.datasets.timestamps;
+const selectLayerLegends = (state) =>
+  state.datasets && state.datasets.layerLegends;
 const getLocation = (state) => state.location && state.location.payload;
 
 export const getLoading = createSelector(
@@ -24,8 +26,8 @@ export const getLoading = createSelector(
 );
 
 const getLegendLayerGroups = createSelector(
-  [getLayerGroups, selectLayerTimestamps],
-  (groups, layerTimestamps) => {
+  [getLayerGroups, selectLayerTimestamps, selectLayerLegends],
+  (groups, layerTimestamps, layerLegends) => {
     if (!groups) return null;
 
     const lGroups = groups.filter((g) => !g.isBoundary && !g.isRecentImagery);
@@ -35,6 +37,15 @@ const getLegendLayerGroups = createSelector(
         group.layers &&
         group.layers.map((l) => {
           const timestampsForLayer = layerTimestamps[l.id];
+
+          // Override legendConfig with image from GetCapabilities
+          const legendUrl = layerLegends && layerLegends[l.id];
+          if (legendUrl && l.legendConfig?.type === "wms_capabilities") {
+            l.legendConfig = {
+              type: "image",
+              imageUrl: legendUrl,
+            };
+          }
 
           if (l.paramsSelectorConfig) {
             const paramsSelectorConfig = [...l.paramsSelectorConfig];

--- a/src/providers/datasets-provider/Update.jsx
+++ b/src/providers/datasets-provider/Update.jsx
@@ -40,24 +40,73 @@ class LayerUpdate extends PureComponent {
     }
   }
 
-  getWMSTimestamps = async () => {
-    const { layer } = this.props;
+  getWMSLayerInfo = async () => {
+    const { layer, legendFromCapabilities } = this.props;
 
     const {
-      id: layerId,
       getCapabilitiesUrl,
       layerName,
-      autoUpdateInterval,
       getCapabilitiesLayerName,
+      styles,
     } = layer;
 
     this.initWmsWorker();
 
     if (this.wmsWorkerRef.current) {
-      return await this.wmsWorkerRef.current.wmsGetLayerTimeFromCapabilities(
+      const styleName = legendFromCapabilities && Array.isArray(styles)
+        ? styles.join(',')
+        : null;
+
+      return await this.wmsWorkerRef.current.wmsGetLayerInfoFromCapabilities(
         getCapabilitiesUrl,
-        getCapabilitiesLayerName || layerName
+        getCapabilitiesLayerName || layerName,
+        styleName
       );
+    }
+
+    return {};
+  };
+
+  processTimestamps = (timestamps) => {
+    const {
+      layer,
+      setMapSettings,
+      setTimestamps,
+      getCurrentLayerTime,
+      activeDatasets,
+    } = this.props;
+
+    const { id: layerId, linkedLayers } = layer;
+
+    setTimestamps({ [layerId]: [...timestamps] });
+
+    if (linkedLayers && !!linkedLayers.length) {
+      linkedLayers.forEach((linkedLayer) => {
+        setTimestamps({ [linkedLayer]: [...timestamps] });
+      });
+    }
+
+    if (timestamps.length) {
+      const newParams = {
+        time: timestamps[timestamps.length - 1],
+      };
+
+      if (getCurrentLayerTime) {
+        const sortedTimestamps = timestamps
+          .slice()
+          .sort((a, b) => parseISO(a) - parseISO(b));
+        newParams.time = getCurrentLayerTime(sortedTimestamps);
+      }
+
+      const newDatasets = activeDatasets.map((l) => {
+        const dataset = { ...l };
+        if (l.layers.includes(layerId)) {
+          dataset.params = { ...dataset.params, ...newParams };
+        }
+        return dataset;
+      });
+
+      setMapSettings({ datasets: newDatasets });
     }
   };
 
@@ -68,12 +117,13 @@ class LayerUpdate extends PureComponent {
       getData,
       setMapSettings,
       setTimestamps,
-      getCurrentLayerTime,
+      setLayerLegend,
       setGeojsonData,
       activeDatasets,
       setLayerUpdatingStatus,
       setLayerLoadingStatus,
       zoomToDataExtent,
+      legendFromCapabilities,
     } = this.props;
 
     const {
@@ -81,8 +131,12 @@ class LayerUpdate extends PureComponent {
       layerType,
       isMultiLayer,
       isDefault,
-      linkedLayers,
+      multiTemporal,
     } = layer;
+
+    const needsWmsCapabilities =
+      layerType === "wms" &&
+      ((!getTimestamps && multiTemporal) || legendFromCapabilities);
 
     let getLayerTimestamps = getTimestamps;
 
@@ -90,12 +144,36 @@ class LayerUpdate extends PureComponent {
       getLayerTimestamps = null;
     }
 
-    if (!getTimestamps && layerType === "wms") {
-      getLayerTimestamps = this.getWMSTimestamps;
-    }
+    if (needsWmsCapabilities) {
+      console.log(`Updating layer : ${layerId}, fetching capabilities`);
 
-    // update timestamps
-    if (getLayerTimestamps) {
+      setLayerUpdatingStatus({ [layerId]: true });
+
+      if (isInitial) {
+        setLayerLoadingStatus({ [layerId]: true });
+      }
+
+      try {
+        const info = await this.getWMSLayerInfo();
+
+        if (info.legendUrl) {
+          setLayerLegend({ [layerId]: info.legendUrl });
+        }
+
+        if (!getTimestamps && multiTemporal) {
+          this.processTimestamps(info.timestamps || []);
+        }
+
+        setLayerUpdatingStatus({ [layerId]: false });
+        if (isInitial) {
+          setLayerLoadingStatus({ [layerId]: false });
+        }
+      } catch (err) {
+        setTimestamps({ [layerId]: [] });
+        setLayerUpdatingStatus({ [layerId]: false });
+        setLayerLoadingStatus({ [layerId]: false });
+      }
+    } else if (getLayerTimestamps) {
       console.log(`Updating layer : ${layerId}, fetching latest timestamps`);
 
       setLayerUpdatingStatus({ [layerId]: true });
@@ -106,44 +184,7 @@ class LayerUpdate extends PureComponent {
 
       getLayerTimestamps()
         .then((timestamps) => {
-          // sort timestamps by date
-          setTimestamps({ [layerId]: [...timestamps] });
-
-          if (linkedLayers && !!linkedLayers.length) {
-            linkedLayers.forEach((linkedLayer) => {
-              setTimestamps({ [linkedLayer]: [...timestamps] });
-            });
-          }
-
-          const newParams = {
-            time: timestamps[timestamps.length - 1],
-          };
-
-          if (getCurrentLayerTime) {
-            const sortedTimestamps =
-              timestamps &&
-              !!timestamps.length &&
-              timestamps.sort((a, b) => parseISO(a) - parseISO(b));
-
-            const newTime = getCurrentLayerTime(sortedTimestamps);
-
-            newParams.time = newTime;
-          }
-
-          const newDatasets = activeDatasets.map((l) => {
-            const dataset = { ...l };
-            if (l.layers.includes(layerId)) {
-              dataset.params = {
-                ...dataset.params,
-                ...newParams,
-              };
-            }
-            return dataset;
-          });
-
-          setMapSettings({
-            datasets: newDatasets,
-          });
+          this.processTimestamps(timestamps);
 
           setLayerUpdatingStatus({ [layerId]: false });
 
@@ -153,9 +194,7 @@ class LayerUpdate extends PureComponent {
         })
         .catch((err) => {
           setTimestamps({ [layerId]: [] });
-
           setLayerUpdatingStatus({ [layerId]: false });
-
           setLayerLoadingStatus({ [layerId]: false });
         });
     }

--- a/src/providers/datasets-provider/actions.js
+++ b/src/providers/datasets-provider/actions.js
@@ -14,6 +14,7 @@ export const setLayerUpdatingStatus = createAction("setLayerUpdatingStatus");
 export const setLayerLoadingStatus = createAction("setLayerLoadingStatus");
 export const setGeojsonData = createAction("setGeojsonData");
 export const setTimestamps = createAction("setTimestamps");
+export const setLayerLegend = createAction("setLayerLegend");
 export const setDatasetParams = createAction("setDatasetParams");
 
 export const fetchDatasets = createThunkAction(

--- a/src/providers/datasets-provider/reducers.js
+++ b/src/providers/datasets-provider/reducers.js
@@ -9,6 +9,7 @@ export const initialState = {
   layerUpdatingStatus: {},
   layerLoadingStatus: {},
   timestamps: {},
+  layerLegends: {},
   params: {},
   geojsonData: {},
 };
@@ -83,6 +84,11 @@ const setTimestamps = (state, { payload }) => ({
   timestamps: { ...state.timestamps, ...payload },
 });
 
+const setLayerLegend = (state, { payload }) => ({
+  ...state,
+  layerLegends: { ...state.layerLegends, ...payload },
+});
+
 const setDatasetParams = (state, { payload }) => {
   const { dataset, params } = payload;
 
@@ -120,6 +126,7 @@ export default {
   [actions.updateDatasets]: updateDatasets,
   [actions.removeDataset]: removeDataset,
   [actions.setTimestamps]: setTimestamps,
+  [actions.setLayerLegend]: setLayerLegend,
   [actions.setDatasetParams]: setDatasetParams,
   [actions.setGeojsonData]: setGeojsonData,
   [actions.setLayerUpdatingStatus]: setLayerUpdatingStatus,

--- a/src/providers/datasets-provider/utils.js
+++ b/src/providers/datasets-provider/utils.js
@@ -71,13 +71,20 @@ const wmsUpdateProvider = (layer) => {
     layerName,
     autoUpdateInterval,
     currentTimeMethod,
+    multiTemporal,
+    legendConfig,
   } = layer;
+
+  const legendFromCapabilities = legendConfig?.type === "wms_capabilities";
 
   return {
     layer: layer,
-    getCurrentLayerTime: (timestamps) => {
-      return getLayerTime(timestamps, currentTimeMethod);
-    },
+    legendFromCapabilities,
+    ...(multiTemporal && {
+      getCurrentLayerTime: (timestamps) => {
+        return getLayerTime(timestamps, currentTimeMethod);
+      },
+    }),
     ...(!!autoUpdateInterval && {
       updateInterval: autoUpdateInterval,
     }),
@@ -116,9 +123,11 @@ const tileLayerUpdateProvider = (layer) => {
 
 export const createUpdateProviders = (activeLayers) => {
   const providers = activeLayers.reduce((all, layer) => {
-    const { layerType, multiTemporal } = layer;
+    const { layerType, multiTemporal, legendConfig } = layer;
 
     let provider;
+
+    const legendFromCapabilities = legendConfig?.type === "wms_capabilities";
 
     if (multiTemporal && layerType) {
       switch (layerType) {
@@ -135,6 +144,8 @@ export const createUpdateProviders = (activeLayers) => {
         default:
           break;
       }
+    } else if (!multiTemporal && layerType === "wms" && legendFromCapabilities) {
+      provider = wmsUpdateProvider(layer);
     }
 
     if (provider) {

--- a/src/providers/datasets-provider/wms-getcaps-worker.js
+++ b/src/providers/datasets-provider/wms-getcaps-worker.js
@@ -2,7 +2,7 @@ import * as Comlink from "comlink";
 import xmldom from "xmldom";
 import WMSCapabilities from "wms-capabilities";
 import { get } from "axios";
-import { subMonths, subDays } from "date-fns";
+import { subDays } from "date-fns";
 
 import { parse, toSeconds } from "iso8601-duration";
 
@@ -28,73 +28,101 @@ function getValidTimestamps(rangeString) {
   return valid_timestamps;
 }
 
-const wmsGetLayerTimeFromCapabilities = async (
+function extractTimestamps(layer) {
+  const timeValueStr =
+    layer?.Dimension?.find((d) => d.name === "time")?.values || "";
+
+  if (!timeValueStr) {
+    return null;
+  }
+
+  const dateRange = timeValueStr.split("/");
+
+  if (dateRange.length > 1) {
+    const isoDuration = dateRange[dateRange.length - 1];
+    const durationMilliseconds = parseISO8601Duration(isoDuration);
+    const durationDays = durationMilliseconds / 8.64e7;
+
+    // if the interval is less than 24 hours, return dates for the past 2 days only
+    // to avoid the browser hanging on large time ranges
+    if (durationDays < 1) {
+      const endTime = new Date(dateRange[1]);
+      const startTime = subDays(endTime, 2);
+
+      return getValidTimestamps(
+        `${startTime.toISOString()}/${endTime.toISOString()}/${isoDuration}`
+      );
+    }
+
+    return getValidTimestamps(timeValueStr);
+  }
+
+  const timestamps = timeValueStr.split(",");
+  timestamps.sort((a, b) => new Date(a) - new Date(b));
+  return timestamps;
+}
+
+function extractLegendUrl(layer, styleName) {
+  const styles = layer?.Style || [];
+  let style;
+
+  if (styleName) {
+    const styleNameLower = styleName.toLowerCase();
+    style = styles.find((s) => s.Name?.toLowerCase() === styleNameLower);
+  }
+
+  // fall back to first style if no match or no style name specified
+  if (!style) {
+    style = styles[0];
+  }
+
+  return style?.LegendURL?.[0]?.OnlineResource || null;
+}
+
+const wmsGetLayerInfoFromCapabilities = async (
   wmsUrl,
   layerName,
+  styleName,
   params = {}
 ) => {
   try {
-    // Fetch the GetCapabilities document from the WMS server
     const response = await get(wmsUrl, {
       params: { ...params },
     });
 
-    // parse xml
     const capabilities = new WMSCapabilities(
       response.data,
       xmldom.DOMParser
     ).toJSON();
 
-    // get all layers
     const layers = capabilities?.Capability?.Layer?.Layer || [];
-
-    // find matching layer by name
     const match = layers.find((l) => l.Name === layerName) || {};
 
-    // get time values
-    const timeValueStr =
-      match?.Dimension?.find((d) => d.name === "time")?.values || [];
+    const result = {};
 
-    let dateRange = timeValueStr.split("/");
-
-    if (!!dateRange.length && dateRange.length > 1) {
-      const isoDuration = dateRange[dateRange.length - 1];
-      const durationMilliseconds = parseISO8601Duration(isoDuration);
-      const durationDays = durationMilliseconds / 8.64e7;
-
-      // if the interval is less that 24 hours, by default return dates for the past one month only.
-      // This is a quick implementation to avoid the browser hanging.
-      // In future we can implement this with web workers to show all the dates
-      if (durationDays < 1) {
-        const endTime = new Date(dateRange[1]);
-        const startTime = subDays(endTime, 2);
-
-        return getValidTimestamps(
-          `${startTime.toISOString()}/${endTime.toISOString()}/${isoDuration}`
-        );
-      }
-
-      return getValidTimestamps(timeValueStr);
+    const timestamps = extractTimestamps(match);
+    if (timestamps) {
+      result.timestamps = timestamps;
     }
 
-    const timestamps = timeValueStr.split(",");
+    if (styleName) {
+      const legendUrl = extractLegendUrl(match, styleName);
+      if (legendUrl) {
+        result.legendUrl = legendUrl;
+      }
+    }
 
-    // sort by date
-    timestamps.sort((a, b) => {
-      return new Date(a) - new Date(b);
-    });
-
-    return timestamps;
+    return result;
   } catch (error) {
     console.error(
       `Error fetching or parsing GetCapabilities document: ${error.message}`
     );
-    return [];
+    return {};
   }
 };
 
 const api = {
-  wmsGetLayerTimeFromCapabilities: wmsGetLayerTimeFromCapabilities,
+  wmsGetLayerInfoFromCapabilities,
 };
 
 Comlink.expose(api);


### PR DESCRIPTION
Handle legend from `getCapabilities` request.

**Rules**

- [x] If the checkbox is checked in the backend, it overrides other custom options for the legend.
- [x] If you specify a `STYLES` in the backend, the legend for this style is fetched.
- [x] Refactoring to share the capabilities calls for Time dimension extraction

<img width="293" height="312" alt="image" src="https://github.com/user-attachments/assets/29e2e9f7-4432-4c65-a824-1d5802ad5d8b" />

```xml
<Style>
<Name>sh_pol_alder_web_surface_concentration</Name>
<Title>Contour shade (Range: 0 / 200000, Multihue pol_alder web)</Title>
<Abstract>Method: contour shade Level range : 0 to 200000 Colour : Multihue pol_alder web</Abstract>
<LegendURL width="350" height="50">
<Format>image/png</Format>
<OnlineResource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:type="simple" xlink:href="https://eccharts.ecmwf.int/wms/?token=public&request=GetLegend&layers=composition_europe_pol_alder_forecast_surface&styles=sh_pol_alder_web_surface_concentration&width=350&height=50"/>
</LegendURL>
</Style>
```