### PR TITLE
wms legend: fix if no STYLE is set

### DIFF
--- a/src/providers/datasets-provider/wms-getcaps-worker.js
+++ b/src/providers/datasets-provider/wms-getcaps-worker.js
@@ -35,11 +35,9 @@ const wmsGetLayerInfoFromCapabilities = async (
       result.timestamps = timestamps;
     }
 
-    if (styleName) {
-      const legendUrl = extractLegendUrl(match, styleName);
-      if (legendUrl) {
-        result.legendUrl = legendUrl;
-      }
+    const legendUrl = extractLegendUrl(match, styleName);
+    if (legendUrl) {
+      result.legendUrl = legendUrl;
     }
 
     return result;


### PR DESCRIPTION
Legend was working only if a specific WMS STYLES option was set.