### PR TITLE
Rework header (user & search)

### DIFF
--- a/src/components/map-menu/components/sections/datasets/component.jsx
+++ b/src/components/map-menu/components/sections/datasets/component.jsx
@@ -4,6 +4,7 @@ import isEmpty from "lodash/isEmpty";
 import cx from "classnames";
 
 import NoContent from "@/components/ui/no-content";
+import Icon from "@/components/ui/icon";
 import LayerToggle from "@/components/map/components/legend/components/layer-toggle";
 
 import Basemaps from "@/components/basemaps";
@@ -12,9 +13,75 @@ import DatasetSection from "./dataset-section";
 import CategoriesMenu from "./categories-menu";
 import LoginForm from "@/components/forms/login";
 
+import { deburrUpper } from "@/utils/strings";
+
+import searchIcon from "@/assets/icons/search.svg?sprite";
+import closeIcon from "@/assets/icons/close.svg?sprite";
+
 import "./styles.scss";
 
 class Datasets extends PureComponent {
+  state = { filter: "" };
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.datasetCategory !== this.props.datasetCategory) {
+      this.setState({ filter: "" });
+    }
+  }
+
+  matchesFilter = (d) => {
+    const { filter } = this.state;
+    if (!filter || !filter.trim()) return true;
+    const term = deburrUpper(filter.trim());
+    return (
+      (d.name && deburrUpper(d.name).includes(term)) ||
+      (d.summary && deburrUpper(d.summary).includes(term)) ||
+      (d.description && deburrUpper(d.description).includes(term))
+    );
+  };
+
+  handleFilterChange = (e) => {
+    this.setState({ filter: e.target.value });
+  };
+
+  clearFilter = () => {
+    this.setState({ filter: "" });
+  };
+
+  handleFilterKeyDown = (e) => {
+    if (e.key === "Escape" && this.state.filter) {
+      e.stopPropagation();
+      this.clearFilter();
+    }
+  };
+
+  renderFilter() {
+    const { filter } = this.state;
+    return (
+      <div className="layers-filter">
+        <Icon icon={searchIcon} className="layers-filter__search-icon" />
+        <input
+          type="text"
+          className="layers-filter__input"
+          placeholder="Filter layers"
+          value={filter}
+          onChange={this.handleFilterChange}
+          onKeyDown={this.handleFilterKeyDown}
+        />
+        {filter && (
+          <button
+            type="button"
+            className="layers-filter__clear"
+            onClick={this.clearFilter}
+            aria-label="Clear filter"
+          >
+            <Icon icon={closeIcon} className="layers-filter__clear-icon" />
+          </button>
+        )}
+      </div>
+    );
+  }
+
   renderLoginWindow() {
     return (
       <div className="login-header">
@@ -70,40 +137,68 @@ class Datasets extends PureComponent {
           <>
             {menuSection && datasetCategory && (
               <Fragment>
-                {subCategories
-                  ? subCategories.map((subCat) => {
-                      const groupKey = `${sectionId}-${subCat.id}`;
-                      let selectedGroup = subCategoryGroupsSelected[groupKey];
-                      // set default group
-                      if (
-                        !selectedGroup &&
-                        subCat.group_options &&
-                        !!subCat.group_options.length
-                      ) {
-                        const defaultGroup =
-                          subCat.group_options.find((o) => o.default) ||
-                          subCat.group_options[0];
+                {this.renderFilter()}
+                {(() => {
+                  const isFiltering =
+                    this.state.filter && this.state.filter.trim().length > 0;
+                  let renderedCount = 0;
 
-                        selectedGroup = defaultGroup.value;
-                      }
+                  if (subCategories) {
+                    const subCategoryNodes = subCategories
+                      .map((subCat) => {
+                        const groupKey = `${sectionId}-${subCat.id}`;
+                        let selectedGroup = subCategoryGroupsSelected[groupKey];
+                        if (
+                          !selectedGroup &&
+                          subCat.group_options &&
+                          !!subCat.group_options.length
+                        ) {
+                          const defaultGroup =
+                            subCat.group_options.find((o) => o.default) ||
+                            subCat.group_options[0];
+                          selectedGroup = defaultGroup.value;
+                        }
 
-                      return (
-                        <DatasetSection
-                          key={subCat.slug}
-                          sectionId={sectionId}
-                          {...subCat}
-                          onToggleCollapse={onToggleSubCategoryCollapse}
-                        >
-                          {subCat.group_options && (
-                            <div className="group-options-wrapper">
-                              {subCat.group_options_title && (
-                                <div className="group-options-title">
-                                  {subCat.group_options_title}
-                                </div>
-                              )}
-                              <div className="group-options">
-                                {subCat.group_options.map((groupOption) => {
-                                  return (
+                        const groupedDatasets = (subCat.datasets || []).filter(
+                          (d) => {
+                            if (
+                              d.group &&
+                              subCat.group_options &&
+                              !!subCat.group_options.length
+                            ) {
+                              return d.group === selectedGroup;
+                            }
+                            return true;
+                          }
+                        );
+
+                        const visibleDatasets = groupedDatasets.filter(
+                          this.matchesFilter
+                        );
+
+                        // when filtering, hide subcategories with no matches
+                        if (isFiltering && visibleDatasets.length === 0) {
+                          return null;
+                        }
+
+                        renderedCount += visibleDatasets.length;
+
+                        return (
+                          <DatasetSection
+                            key={subCat.slug}
+                            sectionId={sectionId}
+                            {...subCat}
+                            onToggleCollapse={onToggleSubCategoryCollapse}
+                          >
+                            {subCat.group_options && !isFiltering && (
+                              <div className="group-options-wrapper">
+                                {subCat.group_options_title && (
+                                  <div className="group-options-title">
+                                    {subCat.group_options_title}
+                                  </div>
+                                )}
+                                <div className="group-options">
+                                  {subCat.group_options.map((groupOption) => (
                                     <div
                                       key={groupOption.value}
                                       className={cx("group-option", {
@@ -119,36 +214,12 @@ class Datasets extends PureComponent {
                                     >
                                       {groupOption.label}
                                     </div>
-                                  );
-                                })}
+                                  ))}
+                                </div>
                               </div>
-                            </div>
-                          )}
-                          {!isEmpty(subCat.datasets) ? (
-                            subCat.datasets.map((d) => {
-                              if (
-                                d.group &&
-                                subCat.group_options &&
-                                !!subCat.group_options.length
-                              ) {
-                                if (d.group && d.group === selectedGroup) {
-                                  return (
-                                    <LayerToggle
-                                      key={d.id}
-                                      className="dataset-toggle"
-                                      data={{ ...d, dataset: d.id }}
-                                      onToggle={onToggleLayer}
-                                      onInfoClick={setModalMetaSettings}
-                                      showSubtitle
-                                      category={datasetCategory}
-                                    />
-                                  );
-                                } else {
-                                  return null;
-                                }
-                              }
-
-                              return (
+                            )}
+                            {!isEmpty(visibleDatasets) ? (
+                              visibleDatasets.map((d) => (
                                 <LayerToggle
                                   key={d.id}
                                   className="dataset-toggle"
@@ -158,29 +229,55 @@ class Datasets extends PureComponent {
                                   showSubtitle
                                   category={datasetCategory}
                                 />
-                              );
-                            })
-                          ) : (
-                            <NoContent
-                              className="no-datasets"
-                              message="No datasets available"
-                            />
-                          )}
-                        </DatasetSection>
+                              ))
+                            ) : (
+                              <NoContent
+                                className="no-datasets"
+                                message="No datasets available"
+                              />
+                            )}
+                          </DatasetSection>
+                        );
+                      })
+                      .filter(Boolean);
+
+                    if (isFiltering && renderedCount === 0) {
+                      return (
+                        <NoContent
+                          className="no-datasets"
+                          message="No layers match your filter"
+                        />
                       );
-                    })
-                  : datasets &&
-                    datasets.map((d, i) => (
-                      <LayerToggle
-                        key={d.id}
-                        tabIndex={i}
-                        className="dataset-toggle"
-                        data={{ ...d, dataset: d.id }}
-                        onToggle={onToggleLayer}
-                        onInfoClick={setModalMetaSettings}
-                        category={datasetCategory}
+                    }
+
+                    return subCategoryNodes;
+                  }
+
+                  const visibleDatasets = (datasets || []).filter(
+                    this.matchesFilter
+                  );
+
+                  if (isFiltering && visibleDatasets.length === 0) {
+                    return (
+                      <NoContent
+                        className="no-datasets"
+                        message="No layers match your filter"
                       />
-                    ))}
+                    );
+                  }
+
+                  return visibleDatasets.map((d, i) => (
+                    <LayerToggle
+                      key={d.id}
+                      tabIndex={i}
+                      className="dataset-toggle"
+                      data={{ ...d, dataset: d.id }}
+                      onToggle={onToggleLayer}
+                      onInfoClick={setModalMetaSettings}
+                      category={datasetCategory}
+                    />
+                  ));
+                })()}
               </Fragment>
             )}
           </>

--- a/src/components/map-menu/components/sections/datasets/styles.scss
+++ b/src/components/map-menu/components/sections/datasets/styles.scss
@@ -160,4 +160,68 @@ $plain-menu: #f1f1f1;
     font-size: rem(13px);
     margin-bottom: rem(10px);
   }
+
+  .layers-filter {
+    display: flex;
+    align-items: center;
+    background-color: $white;
+    border: 1px solid $border-color-2;
+    border-radius: rem(4px);
+    height: rem(34px);
+    padding: 0 rem(8px);
+    margin: rem(10px) rem(15px) rem(15px);
+    transition: border-color 0.15s ease;
+
+    @media screen and (min-width: $screen-m) {
+      margin: 0 rem(20px) rem(15px);
+    }
+
+    &:focus-within {
+      border-color: $primary-color;
+    }
+
+    .layers-filter__search-icon {
+      width: rem(14px);
+      height: rem(14px);
+      fill: $slate;
+      flex-shrink: 0;
+      margin-right: rem(8px);
+    }
+
+    .layers-filter__input {
+      flex: 1 1 auto;
+      border: none;
+      outline: none;
+      background: transparent;
+      font-size: rem(13px);
+      color: $slate-dark;
+      height: 100%;
+      min-width: 0;
+
+      &::placeholder {
+        color: $hot-grey;
+      }
+    }
+
+    .layers-filter__clear {
+      flex-shrink: 0;
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: rem(4px);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+
+      &:hover {
+        background-color: $grey-light;
+      }
+    }
+
+    .layers-filter__clear-icon {
+      width: rem(10px);
+      height: rem(10px);
+      fill: $slate;
+    }
+  }
 }

--- a/src/components/map-menu/icons.js
+++ b/src/components/map-menu/icons.js
@@ -14,6 +14,7 @@ import defaultIcon from "@/assets/icons/layers.svg?sprite";
 import food_security from "@/assets/icons/famine.svg?sprite";
 import alert from "@/assets/icons/alert.svg?sprite";
 import satellite from "@/assets/icons/satellite.svg?sprite";
+import warning from "@/assets/icons/warning.svg?sprite";
 
 export default {
   rainfall,
@@ -32,4 +33,5 @@ export default {
   waterdrop,
   alert,
   satellite,
+  warning
 };

--- a/src/components/map-menu/icons.js
+++ b/src/components/map-menu/icons.js
@@ -15,6 +15,11 @@ import food_security from "@/assets/icons/famine.svg?sprite";
 import alert from "@/assets/icons/alert.svg?sprite";
 import satellite from "@/assets/icons/satellite.svg?sprite";
 import warning from "@/assets/icons/warning.svg?sprite";
+import fire from "@/assets/icons/fires-flame.svg?sprite";
+import vegetation from "@/assets/icons/trees.svg?sprite";
+import forecast from "@/assets/icons/forecast.svg?sprite";
+import climate from "@/assets/icons/climate.svg?sprite";
+import profile from "@/assets/icons/profile.svg?sprite";
 
 export default {
   rainfall,
@@ -33,5 +38,19 @@ export default {
   waterdrop,
   alert,
   satellite,
-  warning
+  "icon-warning": warning,
+  "icon-heavy-rain": rainfall,
+  "icon-heatwave": climate_change,
+  "icon-violent-wind": cyclone,
+  "icon-satellite-dish": satellite,
+  "icon-flood": floods,
+  "icon-drought": drought,
+  "icon-water-source": waterdrop,
+  "icon-environment": env,
+  "icon-fire": fire,
+  "icon-snippet": vegetation,
+  "icon-humanitarian-programme-cycle": forecast,
+  "icon-boat": waterdrop,
+  "icon-site": climate,
+  "icon-group": profile,
 };

--- a/src/components/map-menu/sections.js
+++ b/src/components/map-menu/sections.js
@@ -2,13 +2,21 @@ import layersIcon from "@/assets/icons/layers.svg?sprite";
 import globeIcon from "@/assets/icons/globe.svg?sprite";
 import searchIcon from "@/assets/icons/search.svg?sprite";
 import analysisIcon from "@/assets/icons/analysis.svg?sprite";
-import myAccountIcon from "@/assets/icons/myhw.svg?sprite";
 
 import Analysis from "@/components/analysis";
 import Legend from "@/components/map/components/legend";
 import Datasets from "./components/sections/datasets";
 import Search from "./components/sections/search";
-import MyAccount from "./components/sections/my-account";
+
+export const upperSections = [
+  {
+    label: "search",
+    slug: "search",
+    icon: searchIcon,
+    Component: Search,
+    large: true,
+  },
+];
 
 export const mobileSections = [
   {
@@ -31,26 +39,6 @@ export const mobileSections = [
     Component: Analysis,
     embed: true,
   },
-  {
-    label: "my Account",
-    slug: "my-account",
-    icon: myAccountIcon,
-    Component: MyAccount,
-  },
 ];
 
-export const searchSections = [
-  {
-    label: "search",
-    slug: "search",
-    icon: searchIcon,
-    Component: Search,
-    large: true,
-  },
-  {
-    label: "my Account",
-    slug: "my-account",
-    icon: myAccountIcon,
-    Component: MyAccount,
-  },
-];
+export const searchSections = [];

--- a/src/components/map-menu/selectors.js
+++ b/src/components/map-menu/selectors.js
@@ -13,7 +13,7 @@ import {
 
 import { getEmbed } from "@/layouts/map/selectors";
 
-import { searchSections, mobileSections } from "./sections";
+import { upperSections, searchSections, mobileSections } from "./sections";
 import Datasets from "./components/sections/datasets";
 import icons from "./icons";
 
@@ -28,7 +28,6 @@ const getApiSections = (state) => (state.config && state.config.sections) || [];
 export const selectmapLocationGeostore = (state) =>
   state.geostore && state.geostore.mapLocationGeostore;
 const selectLoggedIn = (state) => state.auth?.data?.loggedIn;
-const selectEnableMyAccount = (state) => state.config?.enableMyAccount;
 
 export const getMenuSection = createSelector(
   [getMenuSettings],
@@ -171,7 +170,10 @@ export const getAllSections = createSelector(
   (datasetSections) => {
     if (!datasetSections) return null;
 
-    return datasetSections.concat(searchSections).concat(mobileSections);
+    return datasetSections
+      .concat(upperSections)
+      .concat(searchSections)
+      .concat(mobileSections);
   }
 );
 
@@ -206,20 +208,22 @@ export const getActiveSectionWithData = createSelector(
   }
 );
 
-export const getSearchSections = createSelector(
-  [getMenuSection, selectEnableMyAccount],
-  (menuSection, myAccountEnabled) => {
-    const sections = searchSections.map((s) => ({
+export const getUpperSections = createSelector(
+  [getMenuSection],
+  (menuSection) =>
+    upperSections.map((s) => ({
       ...s,
       active: menuSection === s.slug,
-    }));
+    }))
+);
 
-    if (!myAccountEnabled) {
-      return sections.filter((s) => s.slug !== "my-account");
-    }
-
-    return sections;
-  }
+export const getSearchSections = createSelector(
+  [getMenuSection],
+  (menuSection) =>
+    searchSections.map((s) => ({
+      ...s,
+      active: menuSection === s.slug,
+    }))
 );
 
 const getLegendLayerGroups = createSelector([getLayerGroups], (groups) => {
@@ -230,15 +234,9 @@ const getLegendLayerGroups = createSelector([getLayerGroups], (groups) => {
 });
 
 export const getMobileSections = createSelector(
-  [
-    getMenuSection,
-    getLegendLayerGroups,
-    getLocation,
-    getEmbed,
-    selectEnableMyAccount,
-  ],
-  (menuSection, activeDatasets, location, embed, myAccountEnabled) => {
-    const sections = mobileSections
+  [getMenuSection, getLegendLayerGroups, getLocation, getEmbed],
+  (menuSection, activeDatasets, location, embed) =>
+    mobileSections
       .filter((s) => !embed || s.embed)
       .map((s) => ({
         ...s,
@@ -249,14 +247,7 @@ export const getMobileSections = createSelector(
           highlight: location && !!location.type && !!location.adm0,
         }),
         active: menuSection === s.slug,
-      }));
-
-    if (!myAccountEnabled) {
-      return sections.filter((s) => s.slug !== "my-account");
-    }
-
-    return sections;
-  }
+      }))
 );
 
 export const getDatasetCategories = createSelector(
@@ -270,6 +261,7 @@ export const getDatasetCategories = createSelector(
 );
 
 export const getMenuProps = createStructuredSelector({
+  upperSections: getUpperSections,
   datasetSections: getDatasetSectionsWithData,
   searchSections: getSearchSections,
   mobileSections: getMobileSections,

--- a/src/components/map/component.jsx
+++ b/src/components/map/component.jsx
@@ -8,6 +8,20 @@ import maplibregl from "maplibre-gl";
 import { Protocol as PmtilesProtocol } from "pmtiles";
 import { cogProtocol } from "@geomatico/maplibre-cog-protocol";
 
+// Register custom maplibre protocols at module load time so they are available
+// before any source using them is added to the map. Registering inside onLoad
+// races with layer-manager adding sources in production builds.
+if (typeof window !== "undefined") {
+  if (!window.__pmtilesRegistered) {
+    maplibregl.addProtocol("pmtiles", new PmtilesProtocol().tile);
+    window.__pmtilesRegistered = true;
+  }
+  if (!window.__cogRegistered) {
+    maplibregl.addProtocol("cog", cogProtocol);
+    window.__cogRegistered = true;
+  }
+}
+
 import { trackMapLatLon, trackEvent } from "@/utils/analytics";
 import { fetchGetFeatureInfo } from "@/services/wms-feature-info";
 
@@ -385,19 +399,6 @@ class MapComponent extends Component {
 
   onLoad = ({ map, mapContainer }, mapSide) => {
     const { setMapSettings } = this.props;
-
-    // Register PMTiles protocol once
-    if (!MapComponent._pmtilesRegistered) {
-      const protocol = new PmtilesProtocol();
-      maplibregl.addProtocol("pmtiles", protocol.tile);
-      MapComponent._pmtilesRegistered = true;
-    }
-
-    // Register COG protocol once
-    if (!MapComponent._cogRegistered) {
-      maplibregl.addProtocol("cog", cogProtocol);
-      MapComponent._cogRegistered = true;
-    }
 
     // remove any if existing
     if (this.state.compareMap) {

--- a/src/components/map/selectors.js
+++ b/src/components/map/selectors.js
@@ -480,6 +480,13 @@ export const getLayersWithSettingsParams = createSelector(
 // Rewrite raster_cog layers to use a `cog://` raster source for the current
 // selected time. Coloring is handled client-side by setColorFunction, so the
 // render layer stays a vanilla raster layer with no special paint.
+// 1x1 transparent PNG used as a placeholder tile while we wait for the COG
+// TileJSON fetch to resolve. An empty `tiles: []` crashes maplibre in
+// production (tiles[NaN].replace(...) during the first render); a no-op data
+// URL keeps the source valid and inert until the real cog:// URL lands.
+const COG_PLACEHOLDER_TILE =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII=";
+
 export const getLayersWithCogSource = createSelector(
   [getLayersWithSettingsParams, selectCogUrls],
   (layers, cogUrls) => {
@@ -495,23 +502,16 @@ export const getLayersWithCogSource = createSelector(
         Object.values(urlsMap)[0] ||
         null;
 
-      // Always hand layer-manager a valid `type: "raster"` source. The backend
-      // emits `source.type: "cog"`, which maplibre would reject. Until the
-      // TileJSON fetch resolves, emit an empty tiles array so layer-manager
-      // can add the (inert) source; once a cogUrl lands, this selector
-      // recomputes and layer-manager swaps in the real `cog://...` source.
       const source = cogUrl
         ? {
             type: "raster",
             url: `cog://${cogUrl}`,
             tileSize: 256,
-            parse: false,
           }
         : {
             type: "raster",
-            tiles: [],
+            tiles: [COG_PLACEHOLDER_TILE],
             tileSize: 256,
-            parse: false,
           };
 
       return {

--- a/src/layouts/map/component.jsx
+++ b/src/layouts/map/component.jsx
@@ -23,6 +23,7 @@ import MapMenu from "@/components/map-menu";
 
 import DataAnalysisMenu from "./components/data-analysis-menu";
 import MapControlButtons from "./components/map-controls";
+import MapHeader from "./components/map-header";
 
 import "./styles.scss";
 
@@ -74,6 +75,7 @@ class MainMapComponent extends PureComponent {
         <Mobile>
           <MapMenu className="map-menu" embed={embed} />
         </Mobile>
+        {!embed && <MapHeader />}
         <div
           className="main-map-container"
           role="button"

--- a/src/layouts/map/components/map-header-search/component.jsx
+++ b/src/layouts/map/components/map-header-search/component.jsx
@@ -1,0 +1,236 @@
+import React, { Component, createRef } from "react";
+import PropTypes from "prop-types";
+import cx from "classnames";
+import debounce from "lodash/debounce";
+
+import Icon from "@/components/ui/icon";
+import { deburrUpper } from "@/utils/strings";
+import { fetchGeocodeNominatim } from "@/services/geocoding";
+import { cancelToken } from "@/utils/request";
+
+import searchIcon from "@/assets/icons/search.svg?sprite";
+import closeIcon from "@/assets/icons/close.svg?sprite";
+import locationIcon from "@/assets/icons/location.svg?sprite";
+import layersIcon from "@/assets/icons/layers.svg?sprite";
+
+import "./styles.scss";
+
+const MAX_LOCATIONS = 10;
+const MAX_DATASETS = 10;
+
+class MapHeaderSearch extends Component {
+  state = {
+    query: "",
+    locations: [],
+    loading: false,
+    open: false,
+  };
+
+  containerRef = createRef();
+
+  componentDidMount() {
+    document.addEventListener("mousedown", this.handleClickOutside);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("mousedown", this.handleClickOutside);
+    this.debouncedSearch.cancel();
+    if (this.searchFetch) {
+      this.searchFetch.cancel("Component unmounted");
+    }
+  }
+
+  handleClickOutside = (e) => {
+    if (
+      this.containerRef.current &&
+      !this.containerRef.current.contains(e.target)
+    ) {
+      this.setState({ open: false });
+    }
+  };
+
+  debouncedSearch = debounce((value) => {
+    if (this.searchFetch) {
+      this.searchFetch.cancel("Cancelling previous search");
+    }
+    this.searchFetch = cancelToken();
+    fetchGeocodeNominatim(value, this.props.lang, this.searchFetch.token)
+      .then((locations) => {
+        this.setState({ locations: locations || [], loading: false });
+      })
+      .catch(() => {
+        this.setState({ loading: false });
+      });
+  }, 400);
+
+  handleChange = (e) => {
+    const value = e.target.value;
+    const trimmed = value.trim();
+    if (trimmed) {
+      this.setState({ query: value, open: true, loading: true });
+      this.debouncedSearch(trimmed);
+    } else {
+      this.debouncedSearch.cancel();
+      if (this.searchFetch) {
+        this.searchFetch.cancel("Search cleared");
+      }
+      this.setState({ query: value, locations: [], loading: false, open: true });
+    }
+  };
+
+  handleClear = () => {
+    this.debouncedSearch.cancel();
+    if (this.searchFetch) {
+      this.searchFetch.cancel("Search cleared");
+    }
+    this.setState({ query: "", locations: [], loading: false, open: false });
+  };
+
+  handleFocus = () => {
+    if (this.state.query) {
+      this.setState({ open: true });
+    }
+  };
+
+  handleClickLocation = (loc) => {
+    this.props.handleClickLocation(loc);
+    this.setState({ open: false });
+  };
+
+  handleClickDataset = (dataset) => {
+    this.props.onToggleDataset(dataset);
+    this.setState({ open: false });
+  };
+
+  getFilteredDatasets() {
+    const { datasets } = this.props;
+    const { query } = this.state;
+    const term = deburrUpper(query.trim());
+    if (!term || !datasets) return [];
+    return datasets
+      .filter(
+        (d) =>
+          (d.name && deburrUpper(d.name).includes(term)) ||
+          (d.localeName && deburrUpper(d.localeName).includes(term)) ||
+          (d.description && deburrUpper(d.description).includes(term))
+      )
+      .slice(0, MAX_DATASETS);
+  }
+
+  renderDropdown() {
+    const { query, locations, loading, open } = this.state;
+
+    if (!open || !query.trim()) return null;
+
+    const filteredDatasets = this.getFilteredDatasets();
+    const hasLocations = locations && locations.length > 0;
+    const hasDatasets = filteredDatasets.length > 0;
+    const isEmpty = !loading && !hasLocations && !hasDatasets;
+
+    return (
+      <div className="map-header-search__dropdown">
+        {hasLocations && (
+          <div className="dropdown-section">
+            <div className="dropdown-section__title">Go to&hellip;</div>
+            <ul className="dropdown-list">
+              {locations.slice(0, MAX_LOCATIONS).map((loc) => (
+                <li key={`${loc.id}-${loc.place_name}`}>
+                  <button
+                    type="button"
+                    className="dropdown-item"
+                    onClick={() => this.handleClickLocation(loc)}
+                  >
+                    <Icon
+                      icon={locationIcon}
+                      className="dropdown-item__icon"
+                    />
+                    <span className="dropdown-item__label">
+                      {loc.place_name}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {hasDatasets && (
+          <div className="dropdown-section">
+            <div className="dropdown-section__title">Add map data</div>
+            <ul className="dropdown-list">
+              {filteredDatasets.map((d) => (
+                <li key={d.id}>
+                  <button
+                    type="button"
+                    className={cx("dropdown-item", { active: d.active })}
+                    onClick={() => this.handleClickDataset(d)}
+                  >
+                    <Icon icon={layersIcon} className="dropdown-item__icon" />
+                    <span className="dropdown-item__label">
+                      {d.localeName || d.name}
+                    </span>
+                    {d.active && (
+                      <span className="dropdown-item__hint">on map</span>
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {loading && !hasLocations && !hasDatasets && (
+          <div className="dropdown-empty">Searching&hellip;</div>
+        )}
+        {isEmpty && (
+          <div className="dropdown-empty">No results for &ldquo;{query}&rdquo;</div>
+        )}
+      </div>
+    );
+  }
+
+  render() {
+    const { query, loading } = this.state;
+
+    return (
+      <div className="c-map-header-search" ref={this.containerRef}>
+        <div
+          className={cx("map-header-search__input-wrapper", { loading })}
+        >
+          <Icon icon={searchIcon} className="map-header-search__search-icon" />
+          <input
+            type="text"
+            className="map-header-search__input"
+            placeholder="Search locations and datasets"
+            value={query}
+            onChange={this.handleChange}
+            onFocus={this.handleFocus}
+          />
+          {query && (
+            <button
+              type="button"
+              className="map-header-search__clear"
+              onClick={this.handleClear}
+              aria-label="Clear search"
+            >
+              <Icon icon={closeIcon} className="map-header-search__clear-icon" />
+            </button>
+          )}
+        </div>
+        {this.renderDropdown()}
+      </div>
+    );
+  }
+}
+
+MapHeaderSearch.propTypes = {
+  datasets: PropTypes.array,
+  lang: PropTypes.string,
+  handleClickLocation: PropTypes.func.isRequired,
+  onToggleDataset: PropTypes.func.isRequired,
+};
+
+MapHeaderSearch.defaultProps = {
+  datasets: [],
+  lang: "en",
+};
+
+export default MapHeaderSearch;

--- a/src/layouts/map/components/map-header-search/component.jsx
+++ b/src/layouts/map/components/map-header-search/component.jsx
@@ -4,6 +4,7 @@ import cx from "classnames";
 import debounce from "lodash/debounce";
 
 import Icon from "@/components/ui/icon";
+import LayerToggle from "@/components/map/components/legend/components/layer-toggle";
 import { deburrUpper } from "@/utils/strings";
 import { fetchGeocodeNominatim } from "@/services/geocoding";
 import { cancelToken } from "@/utils/request";
@@ -11,7 +12,6 @@ import { cancelToken } from "@/utils/request";
 import searchIcon from "@/assets/icons/search.svg?sprite";
 import closeIcon from "@/assets/icons/close.svg?sprite";
 import locationIcon from "@/assets/icons/location.svg?sprite";
-import layersIcon from "@/assets/icons/layers.svg?sprite";
 
 import "./styles.scss";
 
@@ -97,11 +97,6 @@ class MapHeaderSearch extends Component {
     this.setState({ open: false });
   };
 
-  handleClickDataset = (dataset) => {
-    this.props.onToggleDataset(dataset);
-    this.setState({ open: false });
-  };
-
   getFilteredDatasets() {
     const { datasets } = this.props;
     const { query } = this.state;
@@ -158,20 +153,18 @@ class MapHeaderSearch extends Component {
             <div className="dropdown-section__title">Add map data</div>
             <ul className="dropdown-list">
               {filteredDatasets.map((d) => (
-                <li key={d.id}>
-                  <button
-                    type="button"
-                    className={cx("dropdown-item", { active: d.active })}
-                    onClick={() => this.handleClickDataset(d)}
-                  >
-                    <Icon icon={layersIcon} className="dropdown-item__icon" />
-                    <span className="dropdown-item__label">
-                      {d.localeName || d.name}
-                    </span>
-                    {d.active && (
-                      <span className="dropdown-item__hint">on map</span>
-                    )}
-                  </button>
+                <li key={d.id} className="dropdown-dataset">
+                  <LayerToggle
+                    className="dropdown-dataset__toggle"
+                    data={{
+                      ...d,
+                      name: d.localeName || d.name,
+                      dataset: d.id,
+                    }}
+                    onToggle={this.props.onToggleDataset}
+                    onInfoClick={this.props.onInfoClick}
+                    showSubtitle
+                  />
                 </li>
               ))}
             </ul>
@@ -226,6 +219,7 @@ MapHeaderSearch.propTypes = {
   lang: PropTypes.string,
   handleClickLocation: PropTypes.func.isRequired,
   onToggleDataset: PropTypes.func.isRequired,
+  onInfoClick: PropTypes.func.isRequired,
 };
 
 MapHeaderSearch.defaultProps = {

--- a/src/layouts/map/components/map-header-search/index.js
+++ b/src/layouts/map/components/map-header-search/index.js
@@ -1,0 +1,70 @@
+import { connect } from "react-redux";
+import { createSelector, createStructuredSelector } from "reselect";
+import sortBy from "lodash/sortBy";
+
+import { handleClickLocation } from "@/components/map-menu/actions";
+import { setMapSettings } from "@/components/map/actions";
+import { getActiveDatasetsFromState } from "@/components/map/selectors";
+import { selectActiveLang, translateText } from "@/utils/lang";
+
+import Component from "./component";
+
+const selectDatasets = (state) => state.datasets && state.datasets.data;
+
+const getDatasetsWithActive = createSelector(
+  [selectDatasets, getActiveDatasetsFromState, selectActiveLang],
+  (datasets, activeDatasetsState, lang) => {
+    if (!datasets) return [];
+    const activeIds = (activeDatasetsState || []).map((d) => d.dataset);
+    return sortBy(
+      datasets.map((d) => ({
+        ...d,
+        active: activeIds.includes(d.id),
+        localeName: lang === "en" ? d.name : translateText(d.name),
+      })),
+      ["name", "localeName"]
+    );
+  }
+);
+
+const mapStateToProps = createStructuredSelector({
+  datasets: getDatasetsWithActive,
+  lang: selectActiveLang,
+  activeDatasets: getActiveDatasetsFromState,
+});
+
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
+  const { dispatch } = dispatchProps;
+  const { activeDatasets, ...restState } = stateProps;
+
+  return {
+    ...ownProps,
+    ...restState,
+    handleClickLocation: (loc) => dispatch(handleClickLocation(loc)),
+    onToggleDataset: (dataset) => {
+      const enable = !dataset.active;
+      const current = activeDatasets || [];
+
+      const next = enable
+        ? [
+            {
+              dataset: dataset.id,
+              opacity: 1,
+              visibility: true,
+              layers: [dataset.layer],
+            },
+            ...current.filter((l) => l.dataset !== dataset.id),
+          ]
+        : current.filter((l) => l.dataset !== dataset.id);
+
+      dispatch(
+        setMapSettings({
+          datasets: next,
+          ...(enable && { canBound: true }),
+        })
+      );
+    },
+  };
+};
+
+export default connect(mapStateToProps, null, mergeProps)(Component);

--- a/src/layouts/map/components/map-header-search/index.js
+++ b/src/layouts/map/components/map-header-search/index.js
@@ -4,6 +4,7 @@ import sortBy from "lodash/sortBy";
 
 import { handleClickLocation } from "@/components/map-menu/actions";
 import { setMapSettings } from "@/components/map/actions";
+import { setModalMetaSettings } from "@/components/modals/meta/actions";
 import { getActiveDatasetsFromState } from "@/components/map/selectors";
 import { selectActiveLang, translateText } from "@/utils/lang";
 
@@ -41,21 +42,20 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     ...ownProps,
     ...restState,
     handleClickLocation: (loc) => dispatch(handleClickLocation(loc)),
-    onToggleDataset: (dataset) => {
-      const enable = !dataset.active;
+    onToggleDataset: ({ dataset, layer }, enable) => {
       const current = activeDatasets || [];
 
       const next = enable
         ? [
             {
-              dataset: dataset.id,
+              dataset,
               opacity: 1,
               visibility: true,
-              layers: [dataset.layer],
+              layers: [layer],
             },
-            ...current.filter((l) => l.dataset !== dataset.id),
+            ...current.filter((l) => l.dataset !== dataset),
           ]
-        : current.filter((l) => l.dataset !== dataset.id);
+        : current.filter((l) => l.dataset !== dataset);
 
       dispatch(
         setMapSettings({
@@ -64,6 +64,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
         })
       );
     },
+    onInfoClick: (metadata) => dispatch(setModalMetaSettings(metadata)),
   };
 };
 

--- a/src/layouts/map/components/map-header-search/styles.scss
+++ b/src/layouts/map/components/map-header-search/styles.scss
@@ -1,0 +1,170 @@
+@import "@/styles/settings.scss";
+
+.c-map-header-search {
+  position: relative;
+  width: 100%;
+  max-width: rem(520px);
+  font-family: $font-family-1;
+
+  .map-header-search__input-wrapper {
+    display: flex;
+    align-items: center;
+    background-color: $grey-light;
+    border: 1px solid $border;
+    height: rem(36px);
+    padding: 0 rem(8px);
+    transition: border-color 0.15s ease, background-color 0.15s ease;
+
+    &:focus-within {
+      background-color: $white;
+      border-color: $primary-color;
+    }
+
+    &.loading::after {
+      content: "";
+      width: rem(14px);
+      height: rem(14px);
+      border: 2px solid rgba($primary-color, 0.25);
+      border-top-color: $primary-color;
+      animation: map-header-search-spin 0.7s linear infinite;
+      margin-left: rem(6px);
+    }
+  }
+
+  .map-header-search__search-icon {
+    width: rem(16px);
+    height: rem(16px);
+    fill: $slate;
+    flex-shrink: 0;
+    margin-right: rem(8px);
+  }
+
+  .map-header-search__input {
+    flex: 1 1 auto;
+    border: none;
+    outline: none;
+    background: transparent;
+    font-size: $font-size-s;
+    color: $slate-dark;
+    height: 100%;
+    min-width: 0;
+
+    &::placeholder {
+      color: $hot-grey;
+    }
+  }
+
+  .map-header-search__clear {
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: rem(4px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover {
+      background-color: $grey-light;
+    }
+  }
+
+  .map-header-search__clear-icon {
+    width: rem(12px);
+    height: rem(12px);
+    fill: $slate;
+  }
+
+  .map-header-search__dropdown {
+    position: absolute;
+    top: calc(100% + rem(4px));
+    left: 0;
+    right: 0;
+    background: $white;
+    border: 1px solid $border-color-2;
+    box-shadow: $pop-box-shadow;
+    max-height: rem(420px);
+    overflow-y: auto;
+  }
+
+  .dropdown-section + .dropdown-section {
+    border-top: 1px solid $border;
+  }
+
+  .dropdown-section__title {
+    padding: rem(8px) rem(12px);
+    font-size: $font-size-xs;
+    font-weight: $font-weight-bold;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: $white;
+    background-color: $slate;
+  }
+
+  .dropdown-list {
+    list-style: none;
+    margin: 0;
+    padding: rem(4px) 0;
+  }
+
+  .dropdown-item {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    background: none;
+    border: none;
+    padding: rem(8px) rem(12px);
+    text-align: left;
+    cursor: pointer;
+    font-size: $font-size-s;
+    color: $slate-dark;
+    transition: background-color 0.1s ease;
+
+    &:hover,
+    &:focus {
+      background-color: $grey-light;
+      outline: none;
+    }
+
+    &.active {
+      background-color: rgba($primary-color, 0.08);
+    }
+  }
+
+  .dropdown-item__icon {
+    width: rem(14px);
+    height: rem(14px);
+    fill: $primary-color;
+    flex-shrink: 0;
+    margin-right: rem(10px);
+  }
+
+  .dropdown-item__label {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .dropdown-item__hint {
+    flex-shrink: 0;
+    margin-left: rem(8px);
+    font-size: $font-size-xs;
+    color: $primary-color;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .dropdown-empty {
+    padding: rem(12px);
+    font-size: $font-size-s;
+    color: $hot-grey;
+    text-align: center;
+  }
+}
+
+@keyframes map-header-search-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/layouts/map/components/map-header-search/styles.scss
+++ b/src/layouts/map/components/map-header-search/styles.scss
@@ -155,6 +155,29 @@
     letter-spacing: 0.04em;
   }
 
+  .dropdown-dataset {
+    padding: rem(8px) rem(12px);
+    transition: background-color 0.1s ease;
+
+    & + .dropdown-dataset {
+      border-top: 1px solid $border;
+    }
+
+    &:hover {
+      background-color: $grey-light;
+    }
+  }
+
+  .dropdown-dataset__toggle {
+    width: 100%;
+
+    .name,
+    .subtitle {
+      cursor: default;
+      pointer-events: none;
+    }
+  }
+
   .dropdown-empty {
     padding: rem(12px);
     font-size: $font-size-s;

--- a/src/layouts/map/components/map-header-user/component.jsx
+++ b/src/layouts/map/components/map-header-user/component.jsx
@@ -1,0 +1,129 @@
+import React, { Component, createRef } from "react";
+import PropTypes from "prop-types";
+import cx from "classnames";
+
+import Icon from "@/components/ui/icon";
+import MyAccount from "@/components/map-menu/components/sections/my-account";
+
+import userIcon from "@/assets/icons/user.svg?sprite";
+import closeIcon from "@/assets/icons/close.svg?sprite";
+
+import "./styles.scss";
+
+class MapHeaderUser extends Component {
+  static propTypes = {
+    loggedIn: PropTypes.bool,
+    userData: PropTypes.object,
+    enableMyAccount: PropTypes.bool,
+  };
+
+  state = { open: false };
+
+  containerRef = createRef();
+
+  componentDidMount() {
+    document.addEventListener("mousedown", this.handleClickOutside);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.loggedIn && this.props.loggedIn && this.state.open) {
+      this.setState({ open: false });
+    }
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("mousedown", this.handleClickOutside);
+  }
+
+  closePanel = () => {
+    this.setState({ open: false });
+  };
+
+  handleClickOutside = (e) => {
+    if (
+      this.containerRef.current &&
+      !this.containerRef.current.contains(e.target)
+    ) {
+      this.setState({ open: false });
+    }
+  };
+
+  toggleOpen = () => {
+    this.setState((s) => ({ open: !s.open }));
+  };
+
+  renderTrigger() {
+    const { loggedIn, userData } = this.props;
+
+    if (!loggedIn) {
+      return (
+        <button
+          type="button"
+          className="map-header-user__login"
+          onClick={this.toggleOpen}
+        >
+          Log in
+        </button>
+      );
+    }
+
+    const { full_name, first_name, username, email, avatar } = userData || {};
+    const label = full_name || first_name || username || email || "Account";
+
+    return (
+      <button
+        type="button"
+        className="map-header-user__trigger"
+        onClick={this.toggleOpen}
+        aria-haspopup="true"
+        aria-expanded={this.state.open}
+      >
+        <span className="map-header-user__name">{label}</span>
+        <span className="map-header-user__avatar">
+          {avatar ? (
+            <img
+              src={avatar}
+              alt={label}
+              className="map-header-user__avatar-image"
+            />
+          ) : (
+            <Icon icon={userIcon} className="map-header-user__avatar-icon" />
+          )}
+        </span>
+      </button>
+    );
+  }
+
+  render() {
+    const { enableMyAccount } = this.props;
+    const { open } = this.state;
+
+    if (enableMyAccount === false) return null;
+
+    return (
+      <div
+        className={cx("c-map-header-user", { open })}
+        ref={this.containerRef}
+      >
+        {this.renderTrigger()}
+        {open && (
+          <div className="map-header-user__dropdown">
+            <button
+              type="button"
+              className="map-header-user__close"
+              onClick={this.closePanel}
+              aria-label="Close"
+            >
+              <Icon icon={closeIcon} className="map-header-user__close-icon" />
+            </button>
+            <div className="map-header-user__dropdown-body">
+              <MyAccount isDesktop />
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+export default MapHeaderUser;

--- a/src/layouts/map/components/map-header-user/index.js
+++ b/src/layouts/map/components/map-header-user/index.js
@@ -1,0 +1,21 @@
+import { connect } from "react-redux";
+import { createSelector, createStructuredSelector } from "reselect";
+import isEmpty from "lodash/isEmpty";
+
+import Component from "./component";
+
+const selectAuthData = (state) => state.auth && state.auth.data;
+const selectEnableMyAccount = (state) => state.config?.enableMyAccount;
+
+const selectLoggedIn = createSelector(
+  [selectAuthData],
+  (data) => !isEmpty(data)
+);
+
+const mapStateToProps = createStructuredSelector({
+  loggedIn: selectLoggedIn,
+  userData: selectAuthData,
+  enableMyAccount: selectEnableMyAccount,
+});
+
+export default connect(mapStateToProps)(Component);

--- a/src/layouts/map/components/map-header-user/styles.scss
+++ b/src/layouts/map/components/map-header-user/styles.scss
@@ -1,0 +1,159 @@
+@import "@/styles/settings.scss";
+
+$avatar-size: 32px;
+
+.c-map-header-user {
+  position: relative;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  font-family: $font-family-1;
+}
+
+.map-header-user__login {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: rem(32px);
+  padding: 0 rem(14px);
+  background-color: $slate-dark;
+  color: $white;
+  font-size: $font-size-s;
+  border: none;
+  cursor: pointer;
+  text-transform: capitalize;
+  transition: background-color 0.15s ease;
+
+  &:hover,
+  &:focus {
+    background-color: $slate-light;
+    outline: none;
+  }
+}
+
+.map-header-user__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: rem(8px);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: rem(4px) rem(4px) rem(4px) rem(10px);
+  border-radius: rem(20px);
+  color: $slate-dark;
+  font-size: $font-size-s;
+  transition: background-color 0.15s ease;
+
+  &:hover,
+  &:focus {
+    background-color: $grey-light;
+    outline: none;
+  }
+
+  .c-map-header-user.open & {
+    background-color: $grey-light;
+  }
+}
+
+.map-header-user__name {
+  max-width: rem(160px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: $font-weight-regular;
+
+  @media screen and (max-width: $screen-m) {
+    display: none;
+  }
+}
+
+.map-header-user__avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: rem($avatar-size);
+  height: rem($avatar-size);
+  border-radius: 50%;
+  background-color: $primary-color;
+  color: $white;
+  flex-shrink: 0;
+}
+
+.map-header-user__avatar-icon {
+  width: rem(16px);
+  height: rem(16px);
+  fill: $white;
+}
+
+.map-header-user__avatar-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
+}
+
+.map-header-user__dropdown {
+  position: absolute;
+  top: calc(100% + #{rem(6px)});
+  right: 0;
+  width: rem(360px);
+  max-width: calc(100vw - #{rem(20px)});
+  max-height: calc(100vh - #{rem(80px)});
+  background: $white;
+  border: 1px solid $border-color-2;
+  border-radius: rem(4px);
+  box-shadow: $pop-box-shadow;
+  z-index: 11;
+  display: flex;
+  flex-direction: column;
+}
+
+.map-header-user__dropdown-body {
+  overflow-y: auto;
+  padding-top: rem(32px);
+}
+
+.map-header-user__close {
+  position: absolute;
+  top: rem(6px);
+  right: rem(6px);
+  z-index: 1;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: rem(6px);
+  border-radius: rem(2px);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover,
+  &:focus {
+    background-color: $grey-light;
+    outline: none;
+  }
+}
+
+.map-header-user__close-icon {
+  width: rem(12px);
+  height: rem(12px);
+  fill: $slate;
+}
+
+.c-map-header-user .map-header-user__dropdown {
+
+  // Reset some absolute positioning the MyAccount component uses for the
+  // sidebar context — inside this dropdown it should flow normally.
+  .c-map-menu-my-account {
+    height: auto;
+
+    .my-account .my-account-footer {
+      position: static;
+    }
+
+    .my-account-login-image {
+      display: none;
+    }
+  }
+}

--- a/src/layouts/map/components/map-header/component.jsx
+++ b/src/layouts/map/components/map-header/component.jsx
@@ -2,6 +2,7 @@ import React, {PureComponent} from 'react'
 import PropTypes from 'prop-types'
 
 import MapHeaderSearch from '@/layouts/map/components/map-header-search'
+import MapHeaderUser from '@/layouts/map/components/map-header-user'
 
 import './styles.scss'
 
@@ -47,7 +48,9 @@ class MapHeader extends PureComponent {
           <div className="map-header__search">
             <MapHeaderSearch/>
           </div>
-          <div className="map-header__actions"/>
+          <div className="map-header__actions">
+            <MapHeaderUser/>
+          </div>
         </nav>
       </header>
     )

--- a/src/layouts/map/components/map-header/component.jsx
+++ b/src/layouts/map/components/map-header/component.jsx
@@ -1,0 +1,57 @@
+import React, {PureComponent} from 'react'
+import PropTypes from 'prop-types'
+
+import MapHeaderSearch from '@/layouts/map/components/map-header-search'
+
+import './styles.scss'
+
+class MapHeader extends PureComponent {
+  static propTypes = {
+    logo: PropTypes.shape({
+      imageUrl: PropTypes.string,
+      linkUrl: PropTypes.string,
+      external: PropTypes.bool,
+    }),
+  }
+
+  renderLogo() {
+    const {logo} = this.props
+    const {imageUrl, linkUrl, external} = logo || {}
+
+    if (!imageUrl) return null
+
+    const img = (
+      <img src={imageUrl} alt="Logo" className="map-header__logo-image"/>
+    )
+
+    if (!linkUrl) {
+      return <span className="map-header__logo">{img}</span>
+    }
+
+    return (
+      <a
+        href={linkUrl}
+        className="map-header__logo"
+        {...(external && {target: '_blank', rel: 'noopener noreferrer'})}
+      >
+        {img}
+      </a>
+    )
+  }
+
+  render() {
+    return (
+      <header className="c-map-header">
+        <nav className="navbar" role="navigation" aria-label="main navigation">
+          <div className="map-header__brand">{this.renderLogo()}</div>
+          <div className="map-header__search">
+            <MapHeaderSearch/>
+          </div>
+          <div className="map-header__actions"/>
+        </nav>
+      </header>
+    )
+  }
+}
+
+export default MapHeader

--- a/src/layouts/map/components/map-header/component.jsx
+++ b/src/layouts/map/components/map-header/component.jsx
@@ -1,18 +1,64 @@
-import React, {PureComponent} from 'react'
+import React, {Component, createRef} from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 
+import Icon from '@/components/ui/icon'
 import MapHeaderSearch from '@/layouts/map/components/map-header-search'
 import MapHeaderUser from '@/layouts/map/components/map-header-user'
 
+import menuIcon from '@/assets/icons/menu.svg?sprite'
+import closeIcon from '@/assets/icons/close.svg?sprite'
+
 import './styles.scss'
 
-class MapHeader extends PureComponent {
+class MapHeader extends Component {
   static propTypes = {
     logo: PropTypes.shape({
       imageUrl: PropTypes.string,
       linkUrl: PropTypes.string,
       external: PropTypes.bool,
     }),
+    navigation: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        url: PropTypes.string.isRequired,
+        external: PropTypes.bool,
+      })
+    ),
+  }
+
+  static defaultProps = {
+    navigation: [],
+  }
+
+  state = {menuOpen: false}
+
+  menuRef = createRef()
+
+  componentDidMount() {
+    document.addEventListener('mousedown', this.handleClickOutside)
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleClickOutside)
+  }
+
+  handleClickOutside = (e) => {
+    if (
+      this.state.menuOpen &&
+      this.menuRef.current &&
+      !this.menuRef.current.contains(e.target)
+    ) {
+      this.setState({menuOpen: false})
+    }
+  }
+
+  toggleMobileMenu = () => {
+    this.setState((s) => ({menuOpen: !s.menuOpen}))
+  }
+
+  closeMobileMenu = () => {
+    this.setState({menuOpen: false})
   }
 
   renderLogo() {
@@ -40,11 +86,56 @@ class MapHeader extends PureComponent {
     )
   }
 
+  renderNavItems() {
+    const {navigation} = this.props
+
+    if (!navigation || !navigation.length) return null
+
+    return navigation.map((item) => (
+      <li key={`${item.label}-${item.url}`} className="map-header__nav-item">
+        <a
+          href={item.url}
+          className="map-header__nav-link"
+          onClick={this.closeMobileMenu}
+          {...(item.external && {
+            target: '_blank',
+            rel: 'noopener noreferrer',
+          })}
+        >
+          {item.label}
+        </a>
+      </li>
+    ))
+  }
+
   render() {
+    const {navigation} = this.props
+    const {menuOpen} = this.state
+    const hasNav = navigation && navigation.length > 0
+
     return (
       <header className="c-map-header">
         <nav className="navbar" role="navigation" aria-label="main navigation">
           <div className="map-header__brand">{this.renderLogo()}</div>
+          {hasNav && (
+            <div className="map-header__nav-wrapper" ref={this.menuRef}>
+              <button
+                type="button"
+                className="map-header__burger"
+                aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+                aria-expanded={menuOpen}
+                onClick={this.toggleMobileMenu}
+              >
+                <Icon
+                  icon={menuOpen ? closeIcon : menuIcon}
+                  className="map-header__burger-icon"
+                />
+              </button>
+              <ul className={cx('map-header__nav', {open: menuOpen})}>
+                {this.renderNavItems()}
+              </ul>
+            </div>
+          )}
           <div className="map-header__search">
             <MapHeaderSearch/>
           </div>

--- a/src/layouts/map/components/map-header/index.js
+++ b/src/layouts/map/components/map-header/index.js
@@ -4,9 +4,11 @@ import { createStructuredSelector } from "reselect";
 import Component from "./component";
 
 const selectLogo = (state) => state.config?.logo;
+const selectNavigation = (state) => state.config?.navigation || [];
 
 const mapStateToProps = createStructuredSelector({
   logo: selectLogo,
+  navigation: selectNavigation,
 });
 
 export default connect(mapStateToProps)(Component);

--- a/src/layouts/map/components/map-header/index.js
+++ b/src/layouts/map/components/map-header/index.js
@@ -1,0 +1,12 @@
+import { connect } from "react-redux";
+import { createStructuredSelector } from "reselect";
+
+import Component from "./component";
+
+const selectLogo = (state) => state.config?.logo;
+
+const mapStateToProps = createStructuredSelector({
+  logo: selectLogo,
+});
+
+export default connect(mapStateToProps)(Component);

--- a/src/layouts/map/components/map-header/styles.scss
+++ b/src/layouts/map/components/map-header/styles.scss
@@ -55,6 +55,111 @@ $map-header-height: 50px;
     margin: 0 5px;
   }
 
+  .map-header__nav-wrapper {
+    flex: 0 0 auto;
+    position: relative;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    margin-right: rem(12px);
+  }
+
+  .map-header__burger {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: rem(6px);
+    border-radius: rem(2px);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover,
+    &:focus {
+      background-color: $grey-light;
+      outline: none;
+    }
+
+    @media screen and (min-width: $screen-l) {
+      display: none;
+    }
+  }
+
+  .map-header__burger-icon {
+    width: rem(20px);
+    height: rem(20px);
+    fill: $slate;
+  }
+
+  .map-header__nav {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+
+    @media screen and (max-width: ($screen-l - 0.0625rem)) {
+      position: absolute;
+      top: calc(100% + #{rem(4px)});
+      left: 0;
+      min-width: rem(200px);
+      background: $white;
+      border: 1px solid $border-color-2;
+      border-radius: rem(4px);
+      box-shadow: $pop-box-shadow;
+      padding: rem(4px) 0;
+      z-index: 11;
+      display: none;
+
+      &.open {
+        display: block;
+      }
+    }
+
+    @media screen and (min-width: $screen-l) {
+      display: flex;
+      align-items: center;
+      height: 100%;
+    }
+  }
+
+  .map-header__nav-item {
+    @media screen and (min-width: $screen-l) {
+      display: flex;
+      align-items: center;
+      height: 100%;
+    }
+  }
+
+  .map-header__nav-link {
+    display: block;
+    padding: rem(8px) rem(12px);
+    color: $slate;
+    font-size: $font-size-s;
+    text-transform: uppercase;
+    text-decoration: none;
+    white-space: nowrap;
+    line-height: 1;
+    transition: background-color 0.15s ease, color 0.15s ease;
+
+    &:hover,
+    &:focus {
+      background-color: $grey-light;
+      color: $slate-dark;
+      outline: none;
+      text-decoration: none;
+    }
+
+    @media screen and (min-width: $screen-l) {
+      padding: 0 rem(10px);
+      margin: 0 rem(2px);
+
+      &:hover,
+      &:focus {
+        background-color: transparent;
+        color: $primary-color;
+      }
+    }
+  }
+
   .map-header__search {
     flex: 1 1 auto;
     display: flex;

--- a/src/layouts/map/components/map-header/styles.scss
+++ b/src/layouts/map/components/map-header/styles.scss
@@ -1,0 +1,75 @@
+@import "@/styles/settings.scss";
+
+$map-header-height: 50px;
+
+.c-map-header {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: $map-header-height;
+  z-index: 10;
+  background: $white;
+  border-bottom: 1px solid $border;
+  box-shadow: 0 1px 4px rgba($slate, 0.08);
+
+  .navbar {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    padding: 0 rem(12px);
+    margin: 0;
+    background: transparent;
+    min-height: 0;
+  }
+
+  .map-header__brand {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+    height: 100%;
+    padding: 0 10px;
+    margin: 0 5px;
+    margin-right: rem(16px);
+
+    @media screen and (min-width: $screen-m) {
+      min-width: rem(180px);
+      max-width: rem(280px);
+    }
+  }
+
+  .map-header__logo {
+    display: block;
+    height: 100%;
+    padding: rem(4px) 0;
+    line-height: 0;
+  }
+
+  .map-header__logo-image {
+    height: 100%;
+    max-height: calc(#{$map-header-height} - #{rem(10px)});
+    width: auto;
+    object-fit: contain;
+    padding: 0 10px;
+    margin: 0 5px;
+  }
+
+  .map-header__search {
+    flex: 1 1 auto;
+    display: flex;
+    justify-content: center;
+    min-width: 0;
+  }
+
+  .map-header__actions {
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
+
+    @media screen and (min-width: $screen-m) {
+      min-width: rem(180px);
+      justify-content: flex-end;
+    }
+  }
+}

--- a/src/layouts/map/styles.scss
+++ b/src/layouts/map/styles.scss
@@ -3,6 +3,7 @@
 .c-map-main {
   height: 100%;
   padding-top: 50px;
+  position: relative;
 
   .main-map-container {
     width: 100%;
@@ -73,8 +74,10 @@
 
   &.embed {
     height: 100%;
+    padding-top: 0;
 
     .main-map-container {
+      height: 100%;
       width: 100%;
 
       @media screen and (min-width: $screen-m) {

--- a/src/providers/auth-provider/actions.js
+++ b/src/providers/auth-provider/actions.js
@@ -24,8 +24,9 @@ export const getUserProfile = createThunkAction(
                 dispatch(
                   setAuth({
                     loggedIn: true,
-                    id: data.user_id,
-                    ...(data && data),
+                    ...authResponse.data,
+                    ...data,
+                    id: data.user_id || authResponse.data.id,
                   })
                 );
               }

--- a/src/providers/config-provider/actions.js
+++ b/src/providers/config-provider/actions.js
@@ -24,6 +24,7 @@ export const fetchConfig = createThunkAction(
         disclaimerText,
         enableMyAccount,
         allowSignups,
+        navigation,
       } = config;
 
       const sections = categories
@@ -54,6 +55,7 @@ export const fetchConfig = createThunkAction(
         disclaimerText,
         enableMyAccount,
         allowSignups,
+        navigation: navigation || [],
         sections: sections,
         basemaps: basemaps.reduce((all, item) => {
           item.value = item.label;

--- a/src/providers/config-provider/reducers.js
+++ b/src/providers/config-provider/reducers.js
@@ -12,6 +12,7 @@ export const initialState = {
   logo: {},
   countries: [],
   links: {},
+  navigation: [],
   disclaimerText: "",
   enableMyAccount: false,
   allowSignups: false,

--- a/src/providers/datasets-provider/Update.jsx
+++ b/src/providers/datasets-provider/Update.jsx
@@ -177,8 +177,8 @@ class LayerUpdate extends PureComponent {
         const urls = tileJson?.urls || {};
         const timestamps = tileJson?.timestamps || [];
 
-        setCogUrls({ [layerId]: urls });
         registerCogColorFunctions(urls, layer.colorRamp);
+        setCogUrls({ [layerId]: urls });
 
         if (multiTemporal) {
           this.processTimestamps(timestamps);

--- a/src/services/geocoding.js
+++ b/src/services/geocoding.js
@@ -1,5 +1,3 @@
-import { all, spread } from "axios";
-
 import { nominatimGeocodingRequest } from "@/utils/request";
 
 import { POLITICAL_BOUNDARIES } from "@/data/layers";
@@ -45,23 +43,19 @@ export const fetchGeocodeLocations = (
   lang = "en",
   cancelToken
 ) => {
-  return all([
-    nominatimGeocodingRequest
-      .get(
-        `/search?q=${searchQuery}&format=geojson&&viewbox=${EA_BBOX.toString()}&bounded=1`,
-        {
-          cancelToken,
-        }
-      )
-      .then((res) => {
-        const features =
-          res?.data?.features && parseNominatimRes(res.data.features);
-        return features;
-      })
-      .catch((err) => {
-        return [];
-      }),
-  ]);
+  return nominatimGeocodingRequest
+    .get(
+      `/search?q=${searchQuery}&format=geojson&&viewbox=${EA_BBOX.toString()}&bounded=1`,
+      {
+        cancelToken,
+      }
+    )
+    .then((res) => {
+      const features =
+        res?.data?.features && parseNominatimRes(res.data.features);
+      return features || [];
+    })
+    .catch(() => []);
 };
 
 export const fetchReverseGeocodePoint = ({ lat, lng, cancelToken }) => {


### PR DESCRIPTION
PR for https://github.com/wmo-raf/geomapviewer/issues/19

From https://github.com/wmo-raf/geomanager/pull/48 the geomanager is not responsible anymore to render the mapviewer header.

This PR add a new header, as a frontend component.
The header behaves like the old one
- logo
- navigation settings

It adds a search input and user information.

**user**
- fetch more information from backend (name, avatar etc..)
- display avatar and name if connecter, other wise, a login button
- removed the old my-account behavior from the category list

**search**
- add a search bar which search both location and datasets, and return all in the list.
- add a filter input in dataset list from a category
- move the old search button to the top of the category list
- fix current location search

<img width="848" height="499" alt="image" src="https://github.com/user-attachments/assets/ffe31eca-dd4c-4a25-b246-dc0813415168" />
